### PR TITLE
chore: Pinned github jobs to hash version (#160)

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -10,5 +10,5 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: astral-sh/ruff-action@a7b1296fb5bd3ebb270731d1782bf05a97806e29


### PR DESCRIPTION
- Pinned actions/checkout to tag 4.2.2
- Pinned astral-sh/ruff to tag 3.2.0