### PR TITLE
edit frontend to match what backend returns to display email sender

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -10,7 +10,7 @@ interface Application {
 	application_status: string;
 	received_at: string;
 	subject: string;
-	from: string;
+	email_from: string;
 }
 
 export default function Dashboard() {
@@ -94,7 +94,7 @@ export default function Dashboard() {
 									</TableCell>
 									<TableCell>{new Date(item.received_at).toLocaleDateString() || "--"}</TableCell>
 									<TableCell className="max-w-[300px] truncate">{item.subject || "--"}</TableCell>
-									<TableCell>{item.from || "--"}</TableCell>
+									<TableCell>{item.email_from || "--"}</TableCell>
 								</TableRow>
 							))}
 						</TableBody>


### PR DESCRIPTION
# Pull Request

## Description
<!-- Provide a brief description of the changes introduced by this PR -->
Fix frontend to show sender in dashboard table

## Type of Change
<!-- Put an x in the boxes that apply -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes Made
<!-- List the changes made in this PR -->
1. Edit frontend to match what endpoint returns
2. Sender was not showing because the endpoint returns the sender as "email_from"
3. Use "email_from" and display as sender

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->
Sender now showing up: _(company not showing up bc llm is disabled)_
![Screenshot 2025-03-08 at 5 41 47 AM](https://github.com/user-attachments/assets/4f10f616-3836-4dbf-857e-b13d14b50131)

Info backend returns when endpoint is called:
![Screenshot 2025-03-08 at 5 42 29 AM](https://github.com/user-attachments/assets/59859c3f-04e8-4400-aac0-8e1158c19bcc)
