### PR TITLE
fix non-nullable column for existing rows with server default

### DIFF
--- a/backend/alembic/versions/79b431f2e2f8_add_active_beta_billing_status.py
+++ b/backend/alembic/versions/79b431f2e2f8_add_active_beta_billing_status.py
@@ -20,8 +20,10 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Upgrade schema."""
-    op.add_column('users', sa.Column('is_active', sa.Boolean(), nullable=False, ))
-    op.add_column('users', sa.Column('stripe_customer_id', sqlmodel.sql.sqltypes.AutoString(), nullable=True, server_default='false'))
+    op.add_column('users', sa.Column('is_active', sa.Boolean(), nullable=False, server_default=sa.text('true')))
+    op.add_column('users', sa.Column('stripe_customer_id', sqlmodel.sql.sqltypes.AutoString(), nullable=True))
+    # change server default so future users are added as inactive - stripe automation will change this value automatically
+    op.alter_column('users', 'server_default', server_default=sa.text('false'))
     # ### end Alembic commands ###
 
 


### PR DESCRIPTION
# Pull Request

## Description

Failed deployment after enabling alembic in #693 

<img width="769" height="234" alt="CleanShot 2025-12-27 at 23 44 55" src="https://github.com/user-attachments/assets/cccb7092-6b35-47fb-8dc7-728ade151a91" />

The error you are seeing—`psycopg2.errors.NotNullViolation: column "is_active" of relation "users" contains null values`—occurs because you are trying to add a non-nullable column to a table that already contains data.

### Why this is happening
The Constraint: Your migration `79b431f2e2f8_add_active_beta_billing_status.py` is attempting to execute `ALTER TABLE users ADD COLUMN is_active BOOLEAN NOT NULL`.

Existing Data: Your users table already has rows in it. When the database adds the new `is_active` column, it doesn't know what value to assign to these existing rows, so it defaults to `NULL`.

The Conflict: Since you specified nullable=False, the database rejects the operation because those existing rows would immediately violate the "Not Null" rule.

### How to Fix It
To fix this, you need to tell the database what value to use for existing rows. You can do this by adding a server_default in your migration file.

Go to the migration file mentioned in your logs (`/app/alembic/versions/79b431f2e2f8_add_active_beta_billing_status.py`) and update the `upgrade()` function:

Recommended Fix: Use `server_default`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license. 