### PR TITLE
Nullable set to True for `is_active` new column in Users table

### DIFF
--- a/backend/alembic/versions/79b431f2e2f8_add_active_beta_billing_status.py
+++ b/backend/alembic/versions/79b431f2e2f8_add_active_beta_billing_status.py
@@ -20,7 +20,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Upgrade schema."""
-    op.add_column('users', sa.Column('is_active', sa.Boolean(), nullable=False, server_default=sa.text('true')))
+    op.add_column('users', sa.Column('is_active', sa.Boolean(), nullable=True, server_default=sa.text('true')))
     op.add_column('users', sa.Column('stripe_customer_id', sqlmodel.sql.sqltypes.AutoString(), nullable=True))
     # change server default so future users are added as inactive - stripe automation will change this value automatically
     op.alter_column('users', 'server_default', server_default=sa.text('false'))


### PR DESCRIPTION
# Pull Request

## Description
<!-- Provide a brief description of the changes introduced by this PR -->

## Related Issue
<!-- Link to the issue that this PR addresses using the syntax: Fixes #123 -->

<img width="784" height="302" alt="CleanShot 2025-12-28 at 00 00 25" src="https://github.com/user-attachments/assets/c9bfab70-20d4-4616-813a-25b1013c7a41" />

Forgot about the `nullable` issue - if the table already exists, column add has to be nullable because the existing values will be null and then filled with the default server value, I think. Let's find out.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license. 