### PR TITLE
Fix passed argument error in alter column command

### DIFF
--- a/backend/alembic/versions/79b431f2e2f8_add_active_beta_billing_status.py
+++ b/backend/alembic/versions/79b431f2e2f8_add_active_beta_billing_status.py
@@ -23,7 +23,7 @@ def upgrade() -> None:
     op.add_column('users', sa.Column('is_active', sa.Boolean(), nullable=True, server_default=sa.text('true')))
     op.add_column('users', sa.Column('stripe_customer_id', sqlmodel.sql.sqltypes.AutoString(), nullable=True))
     # change server default so future users are added as inactive - stripe automation will change this value automatically
-    op.alter_column('users', 'server_default', server_default=sa.text('false'))
+    op.alter_column(table_name='users', column_name='is_active', server_default = sa.text('false'))
     # ### end Alembic commands ###
 
 


### PR DESCRIPTION
# Pull Request

## Description

<img width="746" height="343" alt="CleanShot 2025-12-28 at 00 15 38" src="https://github.com/user-attachments/assets/49666db1-05e7-4be5-972a-0fcc9f926196" />

Gah, overlooked the function signature hints. Hubris.

<img width="1105" height="366" alt="CleanShot 2025-12-28 at 00 16 18" src="https://github.com/user-attachments/assets/d9d18c4e-c7ec-41b9-a70c-e6dc26c8c675" />

vs

bad syntax

`op.alter_column('users', 'server_default', server_default=sa.text('false'))`

resulting in error

```
[28/Dec/2025:07:53:00] sqlalchemy.exc.ProgrammingError: (psycopg2.errors.UndefinedColumn) column "server_default" of relation "users" does not exist
[28/Dec/2025:07:53:00] [SQL: ALTER TABLE users ALTER COLUMN server_default SET DEFAULT false]
```
---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license. 