### PR TITLE
Add Stripe webhook secret input for backend deployment

### DIFF
--- a/.github/actions/deploy-backend-to-lightsail/action.yaml
+++ b/.github/actions/deploy-backend-to-lightsail/action.yaml
@@ -37,6 +37,9 @@ inputs:
   stripe-secret-key:
     description: Stripe Secret Key to read Promo codes
     required: true
+  stripe-webhook-secret:
+    description: Stripe Webhook Secret for verifying webhook signatures
+    required: true
   origin:
     description: Origin
     required: true
@@ -56,6 +59,7 @@ runs:
       echo "::add-mask::${{ inputs.cookie-secret }}"
       echo "::add-mask::${{ inputs.google-api-key }}"
       echo "::add-mask::${{ inputs.stripe-secret-key }}"
+      echo "::add-mask::${{ inputs.stripe-webhook-secret }}"
       echo "::add-mask::${{ inputs.google-client-id }}"
       echo "::add-mask::${{ inputs.google-client-secret }}"
       echo "::add-mask::${{ inputs.ipinfo-token }}"
@@ -185,6 +189,7 @@ runs:
       COOKIE_SECRET: ${{ inputs.cookie-secret }}
       GOOGLE_API_KEY: ${{ inputs.google-api-key }}
       STRIPE_SECRET_KEY: ${{ inputs.stripe-secret-key }}
+      STRIPE_WEBHOOK_SECRET: ${{ inputs.stripe-webhook-secret }}
       GOOGLE_CLIENT_ID: ${{ inputs.google-client-id }}
       GOOGLE_CLIENT_SECRET: ${{ inputs.google-client-secret }}
       GOOGLE_CLIENT_REDIRECT_URI: ${{ inputs.google-client-redirect-uri }}
@@ -199,6 +204,7 @@ runs:
       echo "::add-mask::${COOKIE_SECRET}"
       echo "::add-mask::${GOOGLE_API_KEY}"
       echo "::add-mask::${STRIPE_SECRET_KEY}"
+      echo "::add-mask::${STRIPE_WEBHOOK_SECRET}"
       echo "::add-mask::${GOOGLE_CLIENT_ID}"
       echo "::add-mask::${GOOGLE_CLIENT_SECRET}"
       echo "::add-mask::${GOOGLE_CLIENT_REDIRECT_URI}"
@@ -224,6 +230,7 @@ runs:
               \"IPINFO_TOKEN\": \"${IPINFO_TOKEN}\",
               \"COOKIE_SECRET\": \"${COOKIE_SECRET}\",
               \"STRIPE_SECRET_KEY\": \"${STRIPE_SECRET_KEY}\",
+              \"STRIPE_WEBHOOK_SECRET\": \"${STRIPE_WEBHOOK_SECRET}\",
               \"APP_URL\": \"${APP_URL}\",
               \"API_URL\": \"${API_URL}\",
               \"ENV\": \"prod\",

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,6 +26,7 @@ jobs:
         ls-database-name: ${{ secrets.LS_DATABASE_NAME }}
         cookie-secret: ${{ secrets.COOKIE_SECRET }}
         stripe-secret-key: ${{ secrets.STRIPE_SECRET_KEY }}
+        stripe-webhook-secret: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
         google-api-key: ${{ secrets.GOOGLE_API_KEY }}
         ipinfo-token: ${{ secrets.IPINFO_TOKEN }}
         app-url: ${{ secrets.APP_URL }}


### PR DESCRIPTION
# Pull Request

## Description
<!-- Provide a brief description of the changes introduced by this PR -->
I keep forgetting to add variables to deployment. Ah well.

This was affecting stripe webhook updates - so even if someone purchased premium plan, their plan wouldn't update in the app. 

<img width="547" height="231" alt="CleanShot 2026-02-08 at 12 06 16" src="https://github.com/user-attachments/assets/b7fa3993-e99c-43a8-ace2-cead1d844118" />

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license. 